### PR TITLE
Conjured items

### DIFF
--- a/src/inventory/gilded_rose.js
+++ b/src/inventory/gilded_rose.js
@@ -48,8 +48,7 @@ function isBackstagePass(item) {
 };
 
 function keepItemQualityWithinRange(itemQuality) {
-  const min = 0;
-  const max = 50;
+  const min = 0, max = 50;
   return Math.min(Math.max(itemQuality, min), max);
 };
 
@@ -65,6 +64,9 @@ function determineItemQuality(item, improvesWithAge) {
     // Quality degrades by 1 as default, only if it doesn't improve with age.
     item.quality -= 1;
   }
+
+  // Degrade quality twice as fast if the item has conjured in its name
+  if (item.name.toLowerCase().includes('conjured')) item.quality -= 1;
 
   // Quality has a max of 50 and cannot be negative.
   item.quality = keepItemQualityWithinRange(item.quality);

--- a/src/inventory/gilded_rose.spec.js
+++ b/src/inventory/gilded_rose.spec.js
@@ -55,4 +55,10 @@ describe('`updateQuality`', () => {
     updateQuality([standardItem]);
     expect(standardItem.quality).toBe(50);
   });
+
+  it('Conjured items should degrade twice as fast.', () => {
+    const standardItem = new Item('Conjured Rye', 5, 20);
+    updateQuality([standardItem]);
+    expect(standardItem.quality).toBe(18);
+  });
 });


### PR DESCRIPTION
## Description
- Any item with the word conjured in its name degrades twice as fast.

## Spec

See Issue: [FSA22V2-78](https://sparkbox.atlassian.net/jira/software/c/projects/FSA22V2/boards/125?modal=detail&selectedIssue=FSA22V2-78)

## Validation

- [x] This PR has code changes, and our linters still pass.
- [x] This PR has new code, so new tests were added or updated, and they pass.